### PR TITLE
fix: restore correct WavTokenizer (medium config + large-speech ckpt)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+__pycache__
+*.pyc
+notebooks/
+python-wrapper/
+*.ipynb

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,41 @@
+name: Build and Push Magana TTS Image
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: magana-tts
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lowercase repository owner
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+FROM --platform=linux/amd64 pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
 
 WORKDIR /app
 
-# Install system deps
+# Install system deps (build-essential needed for pesq C extension)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git wget curl \
+    git wget curl build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 pytorch/pytorch:2.11.0-cuda12.8-cudnn9-runtime
+FROM --platform=linux/amd64 pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,14 @@ RUN pip install --no-cache-dir -r requirements-server.txt
 COPY audiotokenizer.py .
 COPY server.py .
 COPY entrypoint.sh .
+COPY models/ ./models/
 COPY default_speakers/ ./default_speakers/
 COPY default_speakers_local/ ./default_speakers_local/
 
 RUN chmod +x /app/entrypoint.sh
 
-ENV WAV_TOKENIZER_CONFIG=/app/wavtokenizer.yaml
-ENV WAV_TOKENIZER_MODEL=/app/wavtokenizer.ckpt
+ENV WAV_TOKENIZER_CONFIG=/app/models/wavtokenizer_smalldata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml
+ENV WAV_TOKENIZER_MODEL=/app/models/WavTokenizer_small_320_24k_4096.ckpt
 ENV MODEL_ID=saheedniyi/YarnGPT2
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN pip install --no-cache-dir -r requirements-server.txt
 COPY audiotokenizer.py .
 COPY server.py .
 COPY entrypoint.sh .
-COPY models/ ./models/
 COPY default_speakers/ ./default_speakers/
 COPY default_speakers_local/ ./default_speakers_local/
 
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh && mkdir -p /app/models
 
 ENV WAV_TOKENIZER_CONFIG=/app/models/wavtokenizer_smalldata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml
 ENV WAV_TOKENIZER_MODEL=/app/models/WavTokenizer_small_320_24k_4096.ckpt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+
+WORKDIR /app
+
+# Install system deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git wget curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps
+COPY requirements-server.txt .
+RUN pip install --no-cache-dir -r requirements-server.txt
+
+# Copy source
+COPY audiotokenizer.py .
+COPY server.py .
+COPY default_speakers/ ./default_speakers/
+COPY default_speakers_local/ ./default_speakers_local/
+
+# Download WavTokenizer artifacts at build time
+RUN mkdir -p /app/wav_models && \
+    wget -q -O /app/wavtokenizer.yaml \
+    "https://huggingface.co/novateur/WavTokenizer-medium-speech-75token/resolve/main/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml" && \
+    pip install gdown && \
+    gdown 1-ASeEkrn4HY49yZWHTASgfGFNXdVnLTt -O /app/wavtokenizer.ckpt
+
+ENV WAV_TOKENIZER_CONFIG=/app/wavtokenizer.yaml
+ENV WAV_TOKENIZER_MODEL=/app/wavtokenizer.ckpt
+ENV MODEL_ID=saheedniyi/YarnGPT2
+
+EXPOSE 8000
+
+CMD ["python", "server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM --platform=linux/amd64 pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+FROM --platform=linux/amd64 pytorch/pytorch:2.11.0-cuda12.8-cudnn9-runtime
 
 WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
 
 # Install system deps (build-essential needed for pesq C extension)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -9,7 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python deps
 COPY requirements-server.txt .
-RUN pip install --no-cache-dir -r requirements-server.txt
+RUN grep -vE "^(torch|torchaudio)(\[.*\])?(==.*)?$" requirements-server.txt > requirements-server-docker.txt \
+    && pip install --no-cache-dir -r requirements-server-docker.txt
 
 # Copy source
 COPY audiotokenizer.py .

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,11 @@ RUN pip install --no-cache-dir -r requirements-server.txt
 # Copy source
 COPY audiotokenizer.py .
 COPY server.py .
+COPY entrypoint.sh .
 COPY default_speakers/ ./default_speakers/
 COPY default_speakers_local/ ./default_speakers_local/
 
-# Download WavTokenizer artifacts at build time
-RUN mkdir -p /app/wav_models && \
-    wget -q -O /app/wavtokenizer.yaml \
-    "https://huggingface.co/novateur/WavTokenizer-medium-speech-75token/resolve/main/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml" && \
-    pip install gdown && \
-    gdown 1-ASeEkrn4HY49yZWHTASgfGFNXdVnLTt -O /app/wavtokenizer.ckpt
+RUN chmod +x /app/entrypoint.sh
 
 ENV WAV_TOKENIZER_CONFIG=/app/wavtokenizer.yaml
 ENV WAV_TOKENIZER_MODEL=/app/wavtokenizer.ckpt
@@ -30,4 +26,4 @@ ENV MODEL_ID=saheedniyi/YarnGPT2
 
 EXPOSE 8000
 
-CMD ["python", "server.py"]
+CMD ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ COPY default_speakers_local/ ./default_speakers_local/
 
 RUN chmod +x /app/entrypoint.sh && mkdir -p /app/models
 
-ENV WAV_TOKENIZER_CONFIG=/app/models/wavtokenizer_smalldata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml
-ENV WAV_TOKENIZER_MODEL=/app/models/WavTokenizer_small_320_24k_4096.ckpt
+ENV WAV_TOKENIZER_CONFIG=/app/models/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml
+ENV WAV_TOKENIZER_MODEL=/app/models/wavtokenizer_large_speech_320_24k.ckpt
 ENV MODEL_ID=saheedniyi/YarnGPT2
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -1,114 +1,33 @@
-# YarnGPT 🎙️
-![image/png](https://github.com/saheedniyi02/yarngpt/blob/main/notebooks%2Faudio_0c026c21-f432-4d20-a86b-899a10d9ed60.webp)
-A text-to-speech model generating natural Nigerian-accented English speech. Built on pure language modeling without external adapters.
+# Magana TTS
 
-Web Url: https://yarngpt.co/
+Magana TTS is a Nigerian-accented text-to-speech service powering the Magana
+voice AI platform. It is forked from [YarnGPT](https://github.com/saheedniyi02/yarngpt)
+and extended with a streaming WebSocket inference server for real-time voice calls.
 
-## Quick Start
+## What's Inside
 
-```python
+- `audiotokenizer.py` — core tokenizer classes (upstream from YarnGPT)
+- `server.py` — FastAPI + WebSocket streaming inference server
+- `Dockerfile` — RunPod GPU deployment image
+- `default_speakers/` — English speaker reference audio codes
+- `default_speakers_local/` — Hausa, Igbo, Yoruba speaker codes
 
-!git clone https://github.com/saheedniyi02/yarngpt.git
+## Running Locally (for development)
 
-pip install outetts uroman
-
-import os
-import re
-import json
-import torch
-import inflect
-import random
-import uroman as ur
-import numpy as np
-import torchaudio
-import IPython
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from outetts.wav_tokenizer.decoder import WavTokenizer
-
-
-!wget https://huggingface.co/novateur/WavTokenizer-medium-speech-75token/resolve/main/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml
-!gdown 1-ASeEkrn4HY49yZWHTASgfGFNXdVnLTt
-
-
-from yarngpt.audiotokenizer import AudioTokenizerV2
-
-tokenizer_path="saheedniyi/YarnGPT2"
-wav_tokenizer_config_path="/content/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
-wav_tokenizer_model_path = "/content/wavtokenizer_large_speech_320_24k.ckpt"
-
-
-audio_tokenizer=AudioTokenizerV2(
-    tokenizer_path,wav_tokenizer_model_path,wav_tokenizer_config_path
-    )
-
-
-model = AutoModelForCausalLM.from_pretrained(tokenizer_path,torch_dtype="auto").to(audio_tokenizer.device)
-
-#change the text
-text="The election was won by businessman and politician, Moshood Abiola, but Babangida annulled the results, citing concerns over national security."
-
-# change the language and voice
-prompt=audio_tokenizer.create_prompt(text,lang="english",speaker_name="idera")
-
-input_ids=audio_tokenizer.tokenize_prompt(prompt)
-
-output  = model.generate(
-            input_ids=input_ids,
-            temperature=0.1,
-            repetition_penalty=1.1,
-            max_length=4000,
-            #num_beams=5,# using a beam size helps for the local languages but not english
-        )
-
-codes=audio_tokenizer.get_codes(output)
-audio=audio_tokenizer.get_audio(codes)
-IPython.display.Audio(audio,rate=24000)
-torchaudio.save(f"Sample.wav", audio, sample_rate=24000)
-
+```bash
+pip install -r requirements-server.txt
+python server.py
 ```
 
-## Features
+The server starts on `ws://localhost:8000/ws`.
 
-- 🗣️ 12 preset voices (6 male, 6 female)
-- 🎯 Trained on 2000+ hours of Nigerian audio
-- 🔊 24kHz high-quality audio output
-- 🚀 Simple API for quick integration
-- 📝 Support for long-form text
+## Deploying to RunPod
 
-## Available Voices
-- Female: zainab, idera, regina, chinenye, joke, remi
-- Male: jude, tayo, umar, osagie, onye, emma
+1. Build the Docker image and push to a registry (Docker Hub or GHCR).
+2. Create a RunPod GPU pod (T4 recommended) using the image.
+3. Set `MAGANA_TTS_URL=wss://<pod-id>-8000.proxy.runpod.net/ws` in the Magana API `.env`.
 
-## Examples
+## Supported Voices
 
-Check out our [demo notebook](link-to-notebook) or listen to [sample outputs](https://huggingface.co/saheedniyi/YarnGPT/tree/main/audio).
-
-## Model Details
-
-- Base: [HuggingFaceTB/SmolLM2-360M](https://huggingface.co/HuggingFaceTB/SmolLM2-360M)
-- Training: 5 epochs on A100 GPU
-- Data: Nigerian movies, podcasts, and open-source audio
-- Architecture: Pure language modeling approach
-
-## Limitations
-
-- English to Nigerian-accented English only
-- May not capture all Nigerian accent variations
-- Training data includes auto-generated content
-
-## Citation
-
-```bibtex
-@misc{yarngpt2025,
-  author = {Saheed Azeez},
-  title = {YarnGPT: Nigerian-Accented English Text-to-Speech Model},
-  year = {2025},
-  publisher = {Hugging Face}
-}
-```
-
-## License
-MIT
-
-## Acknowledgments
-Built with [WavTokenizer](https://github.com/jishengpeng/WavTokenizer) and inspired by [OuteTTS](https://huggingface.co/OuteAI/OuteTTS-0.2-500M/).
+Magana TTS exposes 12 curated personas. The underlying speaker IDs are
+internal implementation details managed by the Magana API.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+YAML_URL="https://huggingface.co/novateur/WavTokenizer-medium-speech-75token/resolve/main/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
+CKPT_GDRIVE_ID="1-ASeEkrn4HY49yZWHTASgfGFNXdVnLTt"
+
+if [ ! -f "$WAV_TOKENIZER_CONFIG" ]; then
+    echo "[entrypoint] Downloading WavTokenizer config..."
+    wget -q -O "$WAV_TOKENIZER_CONFIG" "$YAML_URL"
+fi
+
+if [ ! -f "$WAV_TOKENIZER_MODEL" ]; then
+    echo "[entrypoint] Downloading WavTokenizer checkpoint (~1.5GB)..."
+    pip install -q gdown
+    gdown "$CKPT_GDRIVE_ID" -O "$WAV_TOKENIZER_MODEL"
+fi
+
+echo "[entrypoint] Starting server..."
+exec python server.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 set -e
 
-YAML_URL="https://huggingface.co/novateur/WavTokenizer/resolve/main/wavtokenizer_smalldata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
-CKPT_URL="https://huggingface.co/novateur/WavTokenizer/resolve/main/WavTokenizer_small_320_24k_4096.ckpt"
+# YarnGPT2 emits codes in the WavTokenizer *large-speech* codebook, paired with the
+# medium-speech-75token config (see python-wrapper/yarngpt/core.py). Decoding with any
+# other WavTokenizer variant (e.g. the small-data one) produces speech-like gibberish.
+YAML_URL="https://huggingface.co/novateur/WavTokenizer-medium-speech-75token/resolve/main/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
+# Official YarnGPT source for the ckpt is Google Drive (the HF repo now only hosts an
+# incompatible v2). Override with WAV_TOKENIZER_MODEL_URL to serve it from own storage.
+CKPT_GDRIVE_ID="1-ASeEkrn4HY49yZWHTASgfGFNXdVnLTt"
+CKPT_MIN_BYTES=1700000000  # real ckpt is ~1.75GB; a Drive quota/error page is a few KB
 
 if [ ! -f "$WAV_TOKENIZER_CONFIG" ]; then
     echo "[entrypoint] Downloading WavTokenizer config..."
@@ -11,9 +17,33 @@ else
     echo "[entrypoint] Found WavTokenizer config at $WAV_TOKENIZER_CONFIG"
 fi
 
-if [ ! -f "$WAV_TOKENIZER_MODEL" ]; then
-    echo "[entrypoint] Downloading WavTokenizer checkpoint (~1.5GB)..."
-    curl -L --fail --retry 5 --retry-delay 5 -o "$WAV_TOKENIZER_MODEL" "$CKPT_URL"
+download_ckpt() {
+    if [ -n "$WAV_TOKENIZER_MODEL_URL" ]; then
+        echo "[entrypoint] Downloading WavTokenizer checkpoint from WAV_TOKENIZER_MODEL_URL..."
+        curl -L --fail --retry 5 --retry-delay 5 -o "$WAV_TOKENIZER_MODEL" "$WAV_TOKENIZER_MODEL_URL"
+        return
+    fi
+    echo "[entrypoint] Downloading WavTokenizer checkpoint from Google Drive (~1.75GB)..."
+    # Large Drive files sit behind a confirm interstitial; extract the uuid then download.
+    local cookie_jar interstitial uuid
+    cookie_jar=$(mktemp)
+    interstitial=$(curl -sL -c "$cookie_jar" "https://drive.google.com/uc?export=download&id=${CKPT_GDRIVE_ID}")
+    uuid=$(echo "$interstitial" | grep -oE 'name="uuid" value="[^"]*"' | cut -d'"' -f4)
+    curl -L --fail --retry 10 --retry-delay 10 -C - -b "$cookie_jar" \
+        -o "$WAV_TOKENIZER_MODEL" \
+        "https://drive.usercontent.google.com/download?id=${CKPT_GDRIVE_ID}&export=download&confirm=t&uuid=${uuid}"
+    rm -f "$cookie_jar"
+}
+
+ckpt_size() { stat -c%s "$WAV_TOKENIZER_MODEL" 2>/dev/null || stat -f%z "$WAV_TOKENIZER_MODEL" 2>/dev/null || echo 0; }
+
+if [ ! -f "$WAV_TOKENIZER_MODEL" ] || [ "$(ckpt_size)" -lt "$CKPT_MIN_BYTES" ]; then
+    rm -f "$WAV_TOKENIZER_MODEL"
+    download_ckpt
+    if [ "$(ckpt_size)" -lt "$CKPT_MIN_BYTES" ]; then
+        echo "[entrypoint] ERROR: checkpoint download came back $(ckpt_size) bytes (< $CKPT_MIN_BYTES). Refusing to start with a bad codec." >&2
+        exit 1
+    fi
 else
     echo "[entrypoint] Found WavTokenizer checkpoint at $WAV_TOKENIZER_MODEL"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 set -e
 
-YAML_URL="https://huggingface.co/novateur/WavTokenizer-medium-speech-75token/resolve/main/wavtokenizer_mediumdata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
-CKPT_GDRIVE_ID="1-ASeEkrn4HY49yZWHTASgfGFNXdVnLTt"
+YAML_URL="https://huggingface.co/novateur/WavTokenizer/resolve/main/wavtokenizer_smalldata_frame75_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
+CKPT_URL="https://huggingface.co/novateur/WavTokenizer/resolve/main/WavTokenizer_small_320_24k_4096.ckpt"
 
 if [ ! -f "$WAV_TOKENIZER_CONFIG" ]; then
     echo "[entrypoint] Downloading WavTokenizer config..."
-    wget -q -O "$WAV_TOKENIZER_CONFIG" "$YAML_URL"
+    curl -L --fail --retry 5 --retry-delay 5 -o "$WAV_TOKENIZER_CONFIG" "$YAML_URL"
+else
+    echo "[entrypoint] Found WavTokenizer config at $WAV_TOKENIZER_CONFIG"
 fi
 
 if [ ! -f "$WAV_TOKENIZER_MODEL" ]; then
     echo "[entrypoint] Downloading WavTokenizer checkpoint (~1.5GB)..."
-    pip install -q gdown
-    gdown "$CKPT_GDRIVE_ID" -O "$WAV_TOKENIZER_MODEL"
+    curl -L --fail --retry 5 --retry-delay 5 -o "$WAV_TOKENIZER_MODEL" "$CKPT_URL"
+else
+    echo "[entrypoint] Found WavTokenizer checkpoint at $WAV_TOKENIZER_MODEL"
 fi
 
 echo "[entrypoint] Starting server..."
-exec python server.py
+exec python -u server.py

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,0 +1,9 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.0
+torch
+torchaudio
+transformers==4.47.1
+outetts==0.2.3
+uroman
+numpy
+inflect

--- a/server.py
+++ b/server.py
@@ -1,0 +1,223 @@
+import asyncio
+import audioop
+import json
+import os
+import re
+import threading
+from threading import Event, Thread
+
+import numpy as np
+import torch
+import torchaudio
+import uvicorn
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from transformers import AutoModelForCausalLM, TextIteratorStreamer
+
+from audiotokenizer import AudioTokenizerV2
+
+MODEL_ID = os.environ.get("MODEL_ID", "saheedniyi/YarnGPT2")
+WAV_CONFIG = os.environ.get("WAV_TOKENIZER_CONFIG", "/app/wavtokenizer.yaml")
+WAV_MODEL = os.environ.get("WAV_TOKENIZER_MODEL", "/app/wavtokenizer.ckpt")
+
+CHUNK_TOKENS = 25
+OVERLAP_TOKENS = 2
+SAMPLES_PER_TOKEN = 320  # 24000 Hz / 75 tokens per second
+
+app = FastAPI()
+audio_tokenizer: AudioTokenizerV2 | None = None
+model: AutoModelForCausalLM | None = None
+model_lock = asyncio.Lock()
+
+
+@app.on_event("startup")
+async def load_model() -> None:
+    global audio_tokenizer, model
+    audio_tokenizer = AudioTokenizerV2(MODEL_ID, WAV_MODEL, WAV_CONFIG)
+    model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
+    model = model.to(audio_tokenizer.device)
+    print("[magana-tts] model loaded")
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok", "model_loaded": model is not None}
+
+
+def _resample_and_encode(audio: torch.Tensor, output_format: str) -> bytes:
+    """Resample 24kHz float32 tensor (1, N) to the target format and return bytes."""
+    if output_format == "ulaw_8000":
+        resampled = torchaudio.functional.resample(audio, 24000, 8000)
+        pcm16 = (resampled.squeeze().cpu().numpy() * 32767).astype(np.int16)
+        return audioop.lin2ulaw(pcm16.tobytes(), 2)
+    # pcm_16000
+    resampled = torchaudio.functional.resample(audio, 24000, 16000)
+    pcm16 = (resampled.squeeze().cpu().numpy() * 32767).astype(np.int16)
+    return pcm16.tobytes()
+
+
+def _decode_chunk(
+    codes: list[int],
+    prev_overlap: list[int],
+    is_first: bool,
+    output_format: str,
+) -> bytes:
+    """
+    Decode a batch of audio codes to PCM bytes.
+    Prepends prev_overlap to smooth boundary artifacts, then trims those
+    samples before encoding so the caller receives only the intended chunk.
+    """
+    full_codes = prev_overlap + codes
+    audio = audio_tokenizer.get_audio(full_codes)  # (1, num_samples) at 24kHz
+    if not is_first and prev_overlap:
+        trim = len(prev_overlap) * SAMPLES_PER_TOKEN
+        audio = audio[:, trim:]
+    return _resample_and_encode(audio, output_format)
+
+
+async def _synthesize(
+    ws: WebSocket,
+    text: str,
+    voice_id: str,
+    lang: str,
+    output_format: str,
+    clear_event: Event,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Run inference and stream PCM chunks to the WebSocket."""
+    assert audio_tokenizer is not None and model is not None
+
+    prompt = audio_tokenizer.create_prompt(text, lang=lang, speaker_name=voice_id)
+    input_ids = audio_tokenizer.tokenize_prompt(prompt)
+
+    streamer = TextIteratorStreamer(
+        audio_tokenizer.tokenizer,
+        skip_prompt=True,
+        skip_special_tokens=False,
+    )
+
+    audio_queue: asyncio.Queue[bytes | Exception | None] = asyncio.Queue()
+
+    def generate() -> None:
+        try:
+            model.generate(
+                input_ids=input_ids,
+                temperature=0.1,
+                repetition_penalty=1.1,
+                max_length=4000,
+                streamer=streamer,
+            )
+        except Exception as exc:
+            loop.call_soon_threadsafe(audio_queue.put_nowait, exc)
+
+    def collect_and_decode() -> None:
+        text_buf = ""
+        codes_buf: list[int] = []
+        prev_overlap: list[int] = []
+        is_first = True
+
+        for token_text in streamer:
+            if clear_event.is_set():
+                break
+            text_buf += token_text
+            # Extract complete <|N|> patterns; keep tail that may be partial
+            matches = list(re.finditer(r"<\|(-?\d+)\|>", text_buf))
+            if matches:
+                last_end = matches[-1].end()
+                text_buf = text_buf[last_end:]
+                codes_buf.extend(int(m.group(1)) for m in matches)
+
+            while len(codes_buf) >= CHUNK_TOKENS and not clear_event.is_set():
+                chunk = codes_buf[:CHUNK_TOKENS]
+                codes_buf = codes_buf[CHUNK_TOKENS:]
+                try:
+                    pcm = _decode_chunk(chunk, prev_overlap, is_first, output_format)
+                    prev_overlap = chunk[-OVERLAP_TOKENS:]
+                    is_first = False
+                    loop.call_soon_threadsafe(audio_queue.put_nowait, pcm)
+                except Exception as exc:
+                    loop.call_soon_threadsafe(audio_queue.put_nowait, exc)
+                    return
+
+        # Flush remaining codes
+        if codes_buf and not clear_event.is_set():
+            try:
+                pcm = _decode_chunk(codes_buf, prev_overlap, is_first, output_format)
+                loop.call_soon_threadsafe(audio_queue.put_nowait, pcm)
+            except Exception as exc:
+                loop.call_soon_threadsafe(audio_queue.put_nowait, exc)
+                return
+
+        loop.call_soon_threadsafe(audio_queue.put_nowait, None)  # sentinel
+
+    gen_thread = Thread(target=generate, daemon=True)
+    collect_thread = Thread(target=collect_and_decode, daemon=True)
+    gen_thread.start()
+    collect_thread.start()
+
+    while True:
+        item = await audio_queue.get()
+        if item is None:
+            break
+        if isinstance(item, Exception):
+            raise item
+        await ws.send_bytes(item)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket) -> None:
+    await ws.accept()
+    loop = asyncio.get_event_loop()
+    clear_event = Event()
+
+    try:
+        raw = await ws.receive_text()
+        handshake = json.loads(raw)
+        voice_id: str = handshake.get("voiceId", "idera")
+        output_format: str = handshake.get("outputFormat", "ulaw_8000")
+        # Infer language from voice_id prefix; default to english
+        lang = "english"
+        for prefix in ("hausa", "igbo", "yoruba"):
+            if voice_id.startswith(prefix):
+                lang = prefix
+                break
+
+        if "text" in handshake:
+            # Stream mode: single synthesis then done
+            async with model_lock:
+                clear_event.clear()
+                await _synthesize(ws, handshake["text"], voice_id, lang, output_format, clear_event, loop)
+            await ws.send_json({"type": "done"})
+            return
+
+        # Session mode: multiple text+flush cycles
+        text_buf = ""
+        async for raw_msg in ws.iter_text():
+            msg = json.loads(raw_msg)
+            msg_type = msg.get("type")
+
+            if msg_type == "text":
+                text_buf += msg.get("content", "")
+            elif msg_type == "flush" and text_buf:
+                text_to_speak = text_buf
+                text_buf = ""
+                clear_event.clear()
+                async with model_lock:
+                    await _synthesize(ws, text_to_speak, voice_id, lang, output_format, clear_event, loop)
+                await ws.send_json({"type": "done"})
+            elif msg_type == "clear":
+                clear_event.set()
+                text_buf = ""
+
+    except WebSocketDisconnect:
+        clear_event.set()
+    except Exception as exc:
+        clear_event.set()
+        try:
+            await ws.close(1011)
+        except Exception:
+            pass
+        raise exc
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/server.py
+++ b/server.py
@@ -3,7 +3,7 @@ import audioop
 import json
 import os
 import re
-import threading
+from contextlib import asynccontextmanager
 from threading import Event, Thread
 
 import numpy as np
@@ -23,19 +23,22 @@ CHUNK_TOKENS = 25
 OVERLAP_TOKENS = 2
 SAMPLES_PER_TOKEN = 320  # 24000 Hz / 75 tokens per second
 
-app = FastAPI()
 audio_tokenizer: AudioTokenizerV2 | None = None
 model: AutoModelForCausalLM | None = None
 model_lock = asyncio.Lock()
 
 
-@app.on_event("startup")
-async def load_model() -> None:
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     global audio_tokenizer, model
     audio_tokenizer = AudioTokenizerV2(MODEL_ID, WAV_MODEL, WAV_CONFIG)
     model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
     model = model.to(audio_tokenizer.device)
     print("[magana-tts] model loaded")
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.get("/health")
@@ -93,6 +96,7 @@ async def _synthesize(
         audio_tokenizer.tokenizer,
         skip_prompt=True,
         skip_special_tokens=False,
+        timeout=30,
     )
 
     audio_queue: asyncio.Queue[bytes | Exception | None] = asyncio.Queue()
@@ -101,6 +105,7 @@ async def _synthesize(
         try:
             model.generate(
                 input_ids=input_ids,
+                do_sample=True,
                 temperature=0.1,
                 repetition_penalty=1.1,
                 max_length=4000,


### PR DESCRIPTION
## Root cause of the gibberish TTS

Commit 58949c9 ("Fix RunPod CUDA runtime for Blackwell") also swapped the WavTokenizer downloads to the **small-data** variant, presumably because the original URLs had gone stale (the HF repo now only hosts an incompatible `_v2` ckpt, and the official source is a Google Drive file).

The small codec has identical tensor shapes (frame75 / nq1 / 4096 codes / dim512), so decoding ran without any error — but its **codebook is from a different training run** than the one YarnGPT2 emits codes for. Every utterance therefore decoded to smooth, speech-like babble: correct format, correct byte-rate, zero intelligible words (confirmed by probing the pod and running the captured audio through Deepgram STT — empty transcript at every sample-rate/endianness interpretation).

## Fix

- Restore the **medium-speech-75token config** (live on HF) + the original **`wavtokenizer_large_speech_320_24k.ckpt`** from YarnGPT's official Google Drive source, handling the large-file confirm interstitial explicitly.
- Add a **size sanity check** (≥1.7GB) so a Drive quota/error page can never silently pose as a model again — the server refuses to start instead.
- Add optional **`WAV_TOKENIZER_MODEL_URL`** override so the ckpt can be served from own storage (recommended follow-up: re-host the 1.75GB file on infrastructure we control).
- The renamed env paths (`wavtokenizer_large_speech_320_24k.ckpt`) automatically invalidate any cached small ckpt on existing RunPod volumes.

## Deploy notes

After merge: rebuild the image (GHCR workflow), redeploy the pod, and re-run a probe — synthesized audio should transcribe correctly via STT.